### PR TITLE
Operators

### DIFF
--- a/src/NoLeftPizza.elm
+++ b/src/NoLeftPizza.elm
@@ -8,7 +8,7 @@ module NoLeftPizza exposing (rule)
 
 import Elm.Syntax.Declaration exposing (Declaration)
 import Elm.Syntax.Expression as Expression exposing (Expression)
-import Elm.Syntax.Infix as Infix exposing (InfixDirection)
+import Elm.Syntax.Infix exposing (InfixDirection)
 import Elm.Syntax.Node as Node exposing (Node)
 import Elm.Syntax.Range as Range
 import Review.Fix as Fix
@@ -104,11 +104,11 @@ expressionVisitor node direction context =
               }
             )
 
-        ( Rule.OnExit, Expression.OperatorApplication op Infix.Left left right ) ->
+        ( Rule.OnExit, Expression.OperatorApplication op dir left right ) ->
             case context.pizzaExpression of
                 Just pizza ->
                     if Node.value left == Node.value pizza.node then
-                        ( [], extendPizza op Infix.Left right node pizza )
+                        ( [], extendPizza op dir right node pizza )
 
                     else
                         ( [], context )

--- a/tests/NoLeftPizzaTest.elm
+++ b/tests/NoLeftPizzaTest.elm
@@ -135,6 +135,33 @@ f =
      y)
         """
                         ]
+        , test "parser operator pizza" <|
+            \() ->
+                """
+module MyParser exposing (..)
+numberToken =
+    Parser.getChompedString <|
+        Parser.succeed ()
+            |. Parser.chompIf Char.isDigit
+            |. Parser.chompWhile Char.isDigit
+"""
+                    |> Review.Test.run NoLeftPizza.rule
+                    |> Review.Test.expectErrors
+                        [ makeError """Parser.getChompedString <|
+        Parser.succeed ()
+            |. Parser.chompIf Char.isDigit
+            |. Parser.chompWhile Char.isDigit"""
+                            |> Review.Test.whenFixed
+                                """
+module MyParser exposing (..)
+numberToken =
+    Parser.getChompedString
+        (Parser.succeed ()
+            |. Parser.chompIf Char.isDigit
+            |. Parser.chompWhile Char.isDigit
+        )
+"""
+                        ]
         ]
 
 

--- a/tests/NoLeftPizzaTest.elm
+++ b/tests/NoLeftPizzaTest.elm
@@ -158,7 +158,7 @@ numberToken =
     Parser.getChompedString (Parser.succeed () |. Parser.chompIf Char.isDigit |. Parser.chompWhile Char.isDigit)
 """
                         ]
-        , test "ignores logic operators" <|
+        , test "handle logic operators with pizza" <|
             \() ->
                 """
 module A exposing (..)
@@ -170,12 +170,12 @@ f =
 """
                     |> Review.Test.run NoLeftPizza.rule
                     |> Review.Test.expectErrors
-                        [ makeError "isTrue <| True"
+                        [ makeError "isTrue <| True || False"
                             |> Review.Test.whenFixed
                                 """
 module A exposing (..)
 f =
-    if isTrue True || False then
+    if isTrue (True || False) then
         True
     else
         False

--- a/tests/NoLeftPizzaTest.elm
+++ b/tests/NoLeftPizzaTest.elm
@@ -135,7 +135,7 @@ f =
      y)
         """
                         ]
-        , test "parser operator pizza" <|
+        , test "handle parser operators with pizza" <|
             \() ->
                 """
 module MyParser exposing (..)
@@ -155,11 +155,30 @@ numberToken =
                                 """
 module MyParser exposing (..)
 numberToken =
-    Parser.getChompedString
-        (Parser.succeed ()
-            |. Parser.chompIf Char.isDigit
-            |. Parser.chompWhile Char.isDigit
-        )
+    Parser.getChompedString (Parser.succeed () |. Parser.chompIf Char.isDigit |. Parser.chompWhile Char.isDigit)
+"""
+                        ]
+        , test "ignores logic operators" <|
+            \() ->
+                """
+module A exposing (..)
+f =
+    if isTrue <| True || False then
+        True
+    else
+        False
+"""
+                    |> Review.Test.run NoLeftPizza.rule
+                    |> Review.Test.expectErrors
+                        [ makeError "isTrue <| True"
+                            |> Review.Test.whenFixed
+                                """
+module A exposing (..)
+f =
+    if isTrue True || False then
+        True
+    else
+        False
 """
                         ]
         ]

--- a/tests/NoLeftPizzaTest.elm
+++ b/tests/NoLeftPizzaTest.elm
@@ -181,7 +181,81 @@ f =
         False
 """
                         ]
+        , describe "mixed pizzas" mixedPizzaTests
         ]
+
+
+mixedPizzaTests : List Test
+mixedPizzaTests =
+    [ test "a <| (b |> c)" <|
+        \() ->
+            """
+module A exposing (..)
+f =
+    a <| (b |> c)
+"""
+                |> Review.Test.run NoLeftPizza.rule
+                |> Review.Test.expectErrors
+                    [ makeError "a <| (b |> c)"
+                        |> Review.Test.whenFixed
+                            """
+module A exposing (..)
+f =
+    a (b |> c)
+"""
+                    ]
+    , test "(a <| b) |> c)" <|
+        \() ->
+            """
+module A exposing (..)
+f =
+    (a <| b) |> c
+"""
+                |> Review.Test.run NoLeftPizza.rule
+                |> Review.Test.expectErrors
+                    [ makeError "a <| b"
+                        |> Review.Test.whenFixed
+                            """
+module A exposing (..)
+f =
+    (a b) |> c
+"""
+                    ]
+    , test "a |> (b <| c)" <|
+        \() ->
+            """
+module A exposing (..)
+f =
+    a |> (b <| c)
+"""
+                |> Review.Test.run NoLeftPizza.rule
+                |> Review.Test.expectErrors
+                    [ makeError "b <| c"
+                        |> Review.Test.whenFixed
+                            """
+module A exposing (..)
+f =
+    a |> (b c)
+"""
+                    ]
+    , test "(a |> b) <| c" <|
+        \() ->
+            """
+module A exposing (..)
+f =
+    (a |> b) <| c
+"""
+                |> Review.Test.run NoLeftPizza.rule
+                |> Review.Test.expectErrors
+                    [ makeError "(a |> b) <| c"
+                        |> Review.Test.whenFixed
+                            """
+module A exposing (..)
+f =
+    (a |> b) c
+"""
+                    ]
+    ]
 
 
 makeError : String -> Review.Test.ExpectedError


### PR DESCRIPTION
Thanks for this rule! I found an issue with a parser that I'd written where the fix didn't grab enough (example below). Most of the code was already there to make this work. I've removed `buildErrors` from the non-pizza operators branch and added a final evaluation to pick up any remaining pizza, and then extended any "left" operators where the pizza is on the left. I've also added a right operator test (see `||`) to make sure that is not affected.

## Failure

```elm
    Parser.getChompedString <|
        Parser.succeed ()
            |. Parser.chompIf Char.isUpper
            |. Parser.chompWhile Char.isLower
            |. Parser.chompWhile Char.isDigit
```

## When fixed (before this patch)

```elm
    Parser.getChompedString (Parser.succeed ())
        |. Parser.chompIf Char.isUpper
        |. Parser.chompWhile Char.isLower
        |. Parser.chompWhile Char.isDigit
```

## When fixed (after this patch)

```elm
    Parser.getChompedString
        (Parser.succeed ()
            |. Parser.chompIf Char.isUpper
            |. Parser.chompWhile Char.isLower
            |. Parser.chompWhile Char.isDigit
        )
```
